### PR TITLE
Issue 9

### DIFF
--- a/src/patterns/CollectionItem.vue
+++ b/src/patterns/CollectionItem.vue
@@ -24,7 +24,7 @@
 
                         <p class="text--large">{{ item.acf.abstract }}</p>
                         <a class="button button--large button--pink"
-                           :href="`https://www.nccardinal.org/eg/opac/record/${item.acf.record_identifier}`">
+                           :href="item.acf.url">
                             Click
                         </a>
                     </div>
@@ -54,7 +54,7 @@
                     <div class="col-8 mt-0 pl-0 pr-0">
                         <p class="mt-0">{{ item.acf.abstract }}</p>
                         <a class="button button--pink"
-                           :href="`https://www.nccardinal.org/eg/opac/record/${item.acf.record_identifier}`">
+                           :href="item.acf.url">
                             Click
                         </a>
                     </div>

--- a/src/patterns/Showcase.vue
+++ b/src/patterns/Showcase.vue
@@ -14,7 +14,7 @@
                          v-for="(item, index) in collectionItems"
                          v-if="index < 6">
 
-                        <a class="link link--undecorated" :href="`https://www.nccardinal.org/eg/opac/record/${item.acf.record_identifier}`">
+                        <a class="link link--undecorated" :href="item.acf.url">
 
                             <card content-container-class="p-0"
                                   :heading="item.title.rendered"


### PR DESCRIPTION
Now that collection item urls are created on import, point to the ACF url field in the api, rather than hardcoding/templating the url in feathers/tawny