### PR TITLE
Issue 35

### DIFF
--- a/src/patterns/CollectionItem.vue
+++ b/src/patterns/CollectionItem.vue
@@ -89,6 +89,9 @@ export default {
   methods: {
     showcaseCreators(item) {
       const { creators } = item.acf;
+      if(creators == false){
+        return '';
+      }
       const { name: creatorName } = creators.find(creator => creator.name);
       const hasMoreThanOneCreator = creators.length > 1;
 

--- a/src/patterns/Showcase.vue
+++ b/src/patterns/Showcase.vue
@@ -59,6 +59,9 @@ export default {
   methods: {
     showcaseCreators(item) {
       const { creators } = item.acf;
+      if(creators == false){
+        return '';
+      }
       const { name: creatorName } = creators.find(creator => creator.name);
       const hasMoreThanOneCreator = creators.length > 1;
 

--- a/src/patterns/Showcase.vue
+++ b/src/patterns/Showcase.vue
@@ -9,14 +9,15 @@
             <template slot="copy">
 
                 <div class="d-flex flex-wrap">
-                    <div class="col-6 col-md-2"
+                    <div class="col-6 col-md-2 d-flex flex-column flex-fill"
                          :key="item.id"
                          v-for="(item, index) in collectionItems"
                          v-if="index < 6">
 
-                        <a class="link link--undecorated" :href="`https://www.nccardinal.org/eg/opac/record/${item.acf.record_identifier}`">
+                        <a class="link link--undecorated d-flex flex-column flex-fill" :href="`https://www.nccardinal.org/eg/opac/record/${item.acf.record_identifier}`">
 
-                            <card content-container-class="p-0"
+                            <card class="d-flex flex-column justify-content-between flex-fill"
+                                  content-container-class="p-0"
                                   :heading="item.title.rendered"
                                   heading-class="h4 text--bold text--nowrap text--ellipsis"
                                   heading-level="h3"


### PR DESCRIPTION
Return empty string if item.acf.creators is false.

possible alignment fixes: adds flexbox classes to align images to bottom (so missing author doesn't throw off line)