### PR TITLE
Issue-41: event.description returning undefined, point to event.content

### DIFF
--- a/src/patterns/EventCard.vue
+++ b/src/patterns/EventCard.vue
@@ -56,7 +56,7 @@ export default {
      * @returns {string | null}
      */
     getExcerpt(event) {
-      const excerpt = event.excerpt ? event.excerpt : event.description;
+      const excerpt = event.excerpt ? event.excerpt : event.content;
       const excerptContainer = document.createElement('div');
 
       excerptContainer.innerHTML = excerpt;

--- a/src/templates/Event.vue
+++ b/src/templates/Event.vue
@@ -20,7 +20,7 @@
                                  :location="eventObject.venue.venue"
                                  :start="new Date(`${eventObject.start_date}`)"
                                  :end="new Date(`${eventObject.end_date}`)"
-                                 :details="eventObject.description"
+                                 :details="eventObject.content"
                                  inline-template>
 
                     <div class="mb-3">
@@ -67,7 +67,7 @@
 
                     <heading class="text--dark" level="h2">About</heading>
 
-                    <div v-html="eventObject.description"></div>
+                    <div v-html="eventObject.content"></div>
 
                     <heading class="text--dark" level="h3">When</heading>
                     {{eventObject.start_date | moment("dddd, MMMM Do YYYY h:mm a")}}


### PR DESCRIPTION
change event.description to event.content
```
getExcerpt(event) {
      const excerpt = event.excerpt ? event.excerpt : event.content;
      const excerptContainer = document.createElement('div');

      excerptContainer.innerHTML = excerpt;

      return this.truncateExcerpt
        ? `${excerptContainer.textContent.substring(0, 140)} ...`
        : excerptContainer.textContent;
    },
```