### PR TITLE
Issue 52: Configure calls-to-action for home page

### DIFF
--- a/src/patterns/CallToAction.vue
+++ b/src/patterns/CallToAction.vue
@@ -9,8 +9,9 @@
               type="deck">
 
             <template slot="action">
-                <a class="button button--aqua button--large"
-                             :href="link">
+                <a v-if="link"
+                  class="button button--aqua button--large"
+                  :href="link">
                     {{ action }}
                 </a>
             </template>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -182,29 +182,45 @@ export default new Vuex.Store({
 
       return actionsByService;
     },
+
     getContentByService: state => (contentType, serviceName = null, locationName = null) => {
       let contents;
       let contentsFilteredByService = [];
 
       if (locationName && locationName !== 'all') {
         contents = state[contentType].filter(
-          page => page.acf.location.some(location => location.slug === locationName)
-        );
-      } else {
+            page => page.acf.location 
+              ? page.acf.location.some(location => location.slug === locationName)
+              : null
+          );
+
+        /**
+         * If there's no location specific content, let's populate 
+         * content from region-wide content
+         */
+        if(contents.length == 0 ){
+          contents = state[contentType].filter(
+              page => !page.acf.location ||
+              page.acf.location == false ||
+              page.acf.location.some(
+                location => location.slug === 'headquarters')
+            );
+        }
+      } 
+      
+      if(!contents || contents.length <1){
         contents = state[contentType];
       }
-      
+
       if (serviceName && serviceName !== 'any') {
-        contents.forEach(function(content){
-          if (content.acf.services != null && content.acf.services !== false){ 
-          contentsFilteredByService.push(content);
-          }
-        });
-        contentsFilteredByService = contentsFilteredByService.filter(
-          page => page.acf.services.some(service => service.slug === serviceName)
+        contentsFilteredByService = contents.filter(
+          page => page.acf.services
+            ? page.acf.services.some(service => service.slug === serviceName)
+            : null
         );
       }
-      return serviceName ? contentsFilteredByService : contents;
+      
+      return (serviceName && serviceName !== 'any')? contentsFilteredByService : contents;
     },
 
     getEvents: state => (dateString = null, locationName = null) => {

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -140,8 +140,8 @@ export default {
         this.location,
       ).sort((a,b) => (a.acf.priority > b.acf.priority) ? 1
                     : ((b.acf.priority > a.acf.priority) ? -1 
-                    : (a.acf.expire > b.acf.expire) ? -1 
-                    : (b.acf.expire > a.acf.expire) ? 1:  0));
+                    : /* (a.acf.expire > b.acf.expire) ? -1 
+                    : (b.acf.expire > a.acf.expire) ? 1:   */0));
     },
 
     collection() {

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -203,7 +203,7 @@ export default {
                     /* : (a.acf.expire > b.acf.expire) ? -1 
                     : (b.acf.expire > a.acf.expire) ? 1 */:  0));
       } else {
-        ctas.shift();
+        ctas = ctas.slice(1);
       }
       /**
        * Check if they're all equally prioritized, if so return a random item.

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -4,12 +4,12 @@
 
     <main role="main">
 
-      <template v-for="(call, index) in callsToAction" v-if="index === 0">
-        <call-to-action :action="call.acf.action"
-                        :copy="call.acf.copy"
-                        :image="call.acf.image"
-                        :heading="call.acf.heading"
-                        :link="call.acf.link"></call-to-action>
+      <template v-if="primaryCTA">
+        <call-to-action :action="primaryCTA.acf.action"
+                        :copy="primaryCTA.acf.copy"
+                        :image="primaryCTA.acf.image"
+                        :heading="primaryCTA.acf.heading"
+                        :link="primaryCTA.acf.link"></call-to-action>
       </template>
 
       <section class="background--blue-alternate library__section pb-3 pl-md-2 pb-md-4 pt-md-4 pr-md-2">
@@ -86,12 +86,14 @@
 
           </div>
 
-          <div class="col-4 p-0">
-            <call-to-action action="Call to Action"
-                            copy="Data tells a powerful story --
-                      about your content, who reads it, and what's possible"
-                            image="https://source.unsplash.com/random"
-                            heading="Watch the eclipse with us"></call-to-action>
+          <div class="col-4 p-0" v-if="secondaryCTA">
+            <template>
+              <call-to-action :action="secondaryCTA.acf.action"
+                              :copy="secondaryCTA.acf.copy"
+                              :image="secondaryCTA.acf.heading"
+                              :heading="secondaryCTA.acf.heading"
+                              :link="secondaryCTA.acf.link"></call-to-action>
+            </template>
           </div>
 
 
@@ -136,11 +138,26 @@ export default {
         'callsToAction',
         'any',
         this.location,
-      );
+      ).sort((a,b) => (a.acf.priority > b.acf.priority) ? 1
+                    : ((b.acf.priority > a.acf.priority) ? -1 
+                    : (a.acf.expire > b.acf.expire) ? -1 
+                    : (b.acf.expire > a.acf.expire) ? 1:  0));
     },
 
     collection() {
       return this.$store.state.collection;
+    },
+
+    events() {
+      return this.$store.state.events;
+    },
+
+    post() {
+      return this.$store.state.posts[0];
+    },
+
+    primaryCTA(){
+      return this.callsToAction[0];
     },
 
     randomCollectionItem() {
@@ -165,17 +182,45 @@ export default {
       ];
     },
 
-    events() {
-      return this.$store.state.events;
-    },
+    secondaryCTA(){
+      let ctas = this.callsToAction;
+      /*
+      * if there's no more 'location specific' content,
+      * let's look for regional content & filter out primaryCTA
+      * then return a random item for the secondary CTA.
+      */
+      if(ctas.length < 2){
+        ctas = this.$store.state.callsToAction.filter(
+          page => (!page.acf.location ||
+              page.acf.location == false ||
+              page.acf.location.some(
+                location => location.slug === 'headquarters')) &&
+                page.id !== ctas[0].id
+        ).sort(
+          (a,b) => (a.acf.priority > b.acf.priority) ? 1
+                    : ((b.acf.priority > a.acf.priority) ? -1 
+                    /* : (a.acf.expire > b.acf.expire) ? -1 
+                    : (b.acf.expire > a.acf.expire) ? 1 */:  0));
+      } else {
+        ctas.shift();
+      }
+      /**
+       * Check if they're all equally prioritized, if so return a random item.
+       */
+      const priorities = Array.from(new Set(ctas.map(item => item.acf.priority)))
+        .map(priority => {
+          return { 
+            item: ctas.find(item => item.acf.priority === priority ).acf.priority};
+      });
 
-    post() {
-      return this.$store.state.posts[0];
+      let num = priorities.length < 2 ? Math.floor(Math.random() * ctas.length) : 0;
+
+      return ctas[num];
     },
 
     services() {
       return this.$store.state.services;
-    },
+    },    
   },
 
   props: {

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -90,7 +90,7 @@
             <template>
               <call-to-action :action="secondaryCTA.acf.action"
                               :copy="secondaryCTA.acf.copy"
-                              :image="secondaryCTA.acf.heading"
+                              :image="secondaryCTA.acf.image"
                               :heading="secondaryCTA.acf.heading"
                               :link="secondaryCTA.acf.link"></call-to-action>
             </template>

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -88,7 +88,8 @@
 
           <div class="col-lg-4 p-0" v-if="secondaryCTA">
             <template>
-              <call-to-action :action="secondaryCTA.acf.action"
+              <call-to-action class="ml-md-2"
+                              :action="secondaryCTA.acf.action"
                               :copy="secondaryCTA.acf.copy"
                               :image="secondaryCTA.acf.image"
                               :heading="secondaryCTA.acf.heading"

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -59,7 +59,7 @@
 
         <div class="col-md-10 d-md-flex m-auto pb-4 pl-0 pr-0 pt-4">
 
-          <div class="col-md-8 p-0">
+          <div class="col-lg-8 p-0">
 
             <Showcase collection-link="/collection"
                       :collection-items="collection"
@@ -86,7 +86,7 @@
 
           </div>
 
-          <div class="col-4 p-0" v-if="secondaryCTA">
+          <div class="col-lg-4 p-0" v-if="secondaryCTA">
             <template>
               <call-to-action :action="secondaryCTA.acf.action"
                               :copy="secondaryCTA.acf.copy"


### PR DESCRIPTION
- Resolves issue with partial button rendering when link is not present
- Configures "secondary Call-to-action" on home page.
- Sorts/checks CTAs by priority
- Gets regional content if location specific content is unavailable.

